### PR TITLE
increase range of user input to 13

### DIFF
--- a/src/ascii_ui.py
+++ b/src/ascii_ui.py
@@ -84,7 +84,7 @@ class ScreenIO():
 		elif userInput == "e":
 			config.load_config()
 			os.system(self.screen_clear)
-		elif userInput >= 0 and userInput <= 12:
+		elif userInput >= 0 and userInput < len(config.config.items()):
 			newConfigValue = input("New Configuration Value for {0}: ".format(config.get_config_value(userInput)))
 			config.modify_config_value(userInput, newConfigValue)
 			self.renderConfigMenu(config, "Configuration changed.")


### PR DESCRIPTION
input 13 wasn't included to allow changing of target_path, using config.config.items() (currently equal to 14) to not need to remember to update value when config file changed later.

![image](https://user-images.githubusercontent.com/48479774/116951048-38b9bd00-acca-11eb-9a3c-c20a73912d3e.png)
